### PR TITLE
Chart layout autosize fixed

### DIFF
--- a/src/Chart.js
+++ b/src/Chart.js
@@ -12,6 +12,10 @@ export default function (props) {
   }
 
   return (
-    <Plot {...props.spec}/>
+    <Plot {...props.spec}
+      layout = { {autosize: true} }
+      style = { {width: "100%", height: "100%"} }
+      useResizeHandler = "true"
+    />
   )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -557,7 +557,6 @@ audio,
 iframe,
 embed,
 object {
-  display: block;
   vertical-align: middle;
 }
 


### PR DESCRIPTION
- Before plotly chart have default fixed 700px width size.  Now it will auto-size relatively with screen size. 
-  Tool wrapping around the top-right now fixed.

<img width="870" alt="Screen Shot 2020-03-19 at 10 48 32 AM" src="https://user-images.githubusercontent.com/11631101/77033427-54cba380-69cf-11ea-8bc2-236b9c7f1433.png">
