### PR TITLE
Empty column when accessor with non string value eg. '.'

### DIFF
--- a/src/Table.js
+++ b/src/Table.js
@@ -39,7 +39,8 @@ export default class Table extends React.Component {
         columns={this.getFields().map(field => {
           return {
             Header: field.name,
-            accessor: field.name,
+            id: field.name,
+            accessor: val => val[field.name],
             Cell: props => <div className={field.type || ''}>
               <span>{props.value}</span>
             </div>


### PR DESCRIPTION
Currently, when accessor or headers have non-string value column returning empty values eg. "name.first".  This PR resolved that issue. 